### PR TITLE
#33 Repository should have a .ebignore for eb deployments support

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -1,3 +1,6 @@
+# do not want the idea folder
 virt
 .github/
 .env
+.env.local
+.idea


### PR DESCRIPTION
this ebignore file will make sure that only the correct environment file gets deployed to our aws environment. This means that folders such as  .idea and other files / folders will not be a part of the package generated by EB during deployment.